### PR TITLE
link local addr: Do not use xor2 on the first octet of MAC

### DIFF
--- a/gluon-mesh-vpn-wireguard-vxlan/files/lib/gluon/gluon-mesh-wireguard-vxlan/checkuplink
+++ b/gluon-mesh-vpn-wireguard-vxlan/files/lib/gluon/gluon-mesh-wireguard-vxlan/checkuplink
@@ -1,15 +1,10 @@
 #!/bin/sh
 
-xor2() {
-	echo -n "${1:0:1}"
-	echo -n "${1:1:1}" | tr '0123456789abcdef' '23016745ab89efcd'
-}
-
 interface_linklocal() {
 	# We generate a predictable v6 address
 	local macaddr="$(echo $(uci get wireguard.wireguard.privatekey | wg pubkey) |md5sum|sed 's/^\(..\)\(..\)\(..\)\(..\)\(..\).*$/02:\1:\2:\3:\4:\5/')"
 	local oldIFS="$IFS"; IFS=':'; set -- $macaddr; IFS="$oldIFS"
-	echo "fe80::$(xor2 "$1")$2:$3ff:fe$4:$5$6"
+	echo "fe80::$1$2:$3ff:fe$4:$5$6"
 }
 
 clean_port() {


### PR DESCRIPTION
Adopts the functions that generates a link-local ipv6 address based on a EUI64 identifier to get the same result as the server-side Salt code using the `mac2eui64` function from salt.utils.network.

Whether this is ultimately correct is uncertain. We assume the Salt codebase does the right thing.