### PR TITLE
Don't call "wg genkey" in the upgrade script

### DIFF
--- a/gluon-mesh-vpn-wireguard-vxlan/luasrc/lib/gluon/upgrade/400-mesh-vpn-wireguard
+++ b/gluon-mesh-vpn-wireguard-vxlan/luasrc/lib/gluon/upgrade/400-mesh-vpn-wireguard
@@ -5,8 +5,7 @@ local uci = require("simple-uci").cursor()
 local util = require "gluon.util"
 
 local wg_enabled = uci:get_bool('wireguard', 'mesh_vpn', 'enabled') or false
-local privkey = uci:get("wireguard", "mesh_vpn", "privatekey") or
-	util.trim(util.exec("wg genkey"))
+local privkey = uci:get("wireguard", "mesh_vpn", "privatekey") or ""
 
 -- Clean up previous configuration
 uci:delete_all('wireguard', 'peer', function(peer)


### PR DESCRIPTION
Some platforms (namely ER-X) are stuck in the boot process, due to insufficient entropy, when the key is generated in the upgrade script. It can be left empty instead, if no old key is available, it will be created by the checkuplink script later on, when needed.