### PR TITLE
Set fwmark 1 on wg mesh interface to use br-wan

### DIFF
--- a/gluon-mesh-vpn-wireguard-vxlan/files/lib/gluon/gluon-mesh-wireguard-vxlan/checkuplink
+++ b/gluon-mesh-vpn-wireguard-vxlan/files/lib/gluon/gluon-mesh-wireguard-vxlan/checkuplink
@@ -90,6 +90,7 @@ if [ "$(uci get wireguard.mesh_vpn.enabled)" == "true" ] || [ "$(uci get wiregua
 
 		# Bring up the wireguard interface
 		ip link add dev $MESH_VPN_IFACE type wireguard
+		wg set $MESH_VPN_IFACE fwmark 1
 		uci get wireguard.mesh_vpn.privatekey | wg set $MESH_VPN_IFACE private-key /proc/self/fd/0
 		ip link set up dev $MESH_VPN_IFACE
 


### PR DESCRIPTION
Gluon does use two routing tables, one for the local network (br-wan)
and one for the Freifunk network (br-client). Packets are differentiated
based on their packet mark. This change sets the packet mark for the
wireguard packets to 0x1, to make sure they are always sent on br-wan.