### PR TITLE
Use https for wgkex key exchange

### DIFF
--- a/gluon-mesh-vpn-wireguard-vxlan/files/lib/gluon/gluon-mesh-wireguard-vxlan/checkuplink
+++ b/gluon-mesh-vpn-wireguard-vxlan/files/lib/gluon/gluon-mesh-wireguard-vxlan/checkuplink
@@ -92,8 +92,11 @@ if [ "$(uci get wireguard.mesh_vpn.enabled)" == "true" ] || [ "$(uci get wiregua
 		PUBLICKEY=$(uci get wireguard.mesh_vpn.privatekey | wg pubkey)
 		SEGMENT=$(uci get gluon.core.domain)
 
-		# Push public key to broker
-		gluon-wan wget -q  -O- --post-data='{"domain": "'"$SEGMENT"'","public_key": "'"$PUBLICKEY"'"}' http://broker.ffmuc.net/api/v1/wg/key/exchange
+		# Push public key to broker, try https first, fall back to http in case of error
+		gluon-wan wget -q  -O- --post-data='{"domain": "'"$SEGMENT"'","public_key": "'"$PUBLICKEY"'"}' https://broker.ffmuc.net/api/v1/wg/key/exchange
+		if [ $? -ne 0 ]; then
+			gluon-wan wget -q  -O- --post-data='{"domain": "'"$SEGMENT"'","public_key": "'"$PUBLICKEY"'"}' http://broker.ffmuc.net/api/v1/wg/key/exchange
+		fi
 
 		# Bring up the wireguard interface
 		ip link add dev $MESH_VPN_IFACE type wireguard


### PR DESCRIPTION
To avoid unencrypted transmission of the public wireguard key, which could potentially be misused for identification of a node, use https instead of http, on devices where ssl is available.