### PR TITLE
Also check BATMAN connectivity, after wireguard

### DIFF
--- a/gluon-mesh-vpn-wireguard-vxlan/files/lib/gluon/gluon-mesh-wireguard-vxlan/checkuplink
+++ b/gluon-mesh-vpn-wireguard-vxlan/files/lib/gluon/gluon-mesh-wireguard-vxlan/checkuplink
@@ -65,7 +65,11 @@ if [ "$(uci get wireguard.mesh_vpn.enabled)" == "true" ] || [ "$(uci get wiregua
 	# Check connectivity to supernode
 	wget http://[$(wg  | grep fe80 | awk '{split($3,A,"/")};{print A[1]}')%$MESH_VPN_IFACE]/  --timeout=5 -O/dev/null -q
 	if [ "$?" -eq "0" ]; then
+		GWMAC=$(batctl gwl | grep \* | awk '{print $2}')
+		batctl ping -c 5 $GWMAC
+		if [ "$?" -eq "0" ]; then
 			CONNECTED=1
+		fi
 	fi
 
 	# If we don't have a connection we try to connect


### PR DESCRIPTION
Sometimes it happens that the wireguard tunnel is up and running, but BATMAN connectivity is lost. In this case checkuplink does not detect the node is actually disconnected and yanic reporting also keeps working, so it does appear online in the map, but client network for users is not working. This change adds an additional check, whether the current BATMAN gateway is pingable, so BATMAN networking is working as expected.