### PR TITLE
Don't spam logread with connection-check output

### DIFF
--- a/gluon-mesh-vpn-wireguard-vxlan/files/lib/gluon/gluon-mesh-wireguard-vxlan/checkuplink
+++ b/gluon-mesh-vpn-wireguard-vxlan/files/lib/gluon/gluon-mesh-wireguard-vxlan/checkuplink
@@ -66,7 +66,7 @@ if [ "$(uci get wireguard.mesh_vpn.enabled)" == "true" ] || [ "$(uci get wiregua
 	wget http://[$(wg  | grep fe80 | awk '{split($3,A,"/")};{print A[1]}')%$MESH_VPN_IFACE]/  --timeout=5 -O/dev/null -q
 	if [ "$?" -eq "0" ]; then
 		GWMAC=$(batctl gwl | grep \* | awk '{print $2}')
-		batctl ping -c 5 $GWMAC
+		batctl ping -c 5 $GWMAC &> /dev/null
 		if [ "$?" -eq "0" ]; then
 			CONNECTED=1
 		fi


### PR DESCRIPTION
The new batctl ping check did miss output redirection to /dev/null and was spamming logread with useless entries.