### PR TITLE
Revert "Add mesh-vpn to BATMAN, as Gluon does not do it anymore"

### DIFF
--- a/ffmuc-mesh-vpn-wireguard-vxlan/files/lib/gluon/gluon-mesh-wireguard-vxlan/checkuplink
+++ b/ffmuc-mesh-vpn-wireguard-vxlan/files/lib/gluon/gluon-mesh-wireguard-vxlan/checkuplink
@@ -116,9 +116,6 @@ if [ "$(uci get wireguard.mesh_vpn.enabled)" == "true" ] || [ "$(uci get wiregua
 		# Bring up VXLAN
 		ip link add mesh-vpn type vxlan id "$(lua -e 'print(tonumber(require("gluon.util").domain_seed_bytes("gluon-mesh-vpn-vxlan", 3), 16))')" local $(interface_linklocal "$MESH_VPN_IFACE") remote $(uci get wireguard.peer_$PEER.link_address) dstport 8472 dev $MESH_VPN_IFACE
 		ip link set up dev mesh-vpn
-		
-		# Add VXLAN inteface to BATMAN
-		batctl if add mesh-vpn
 
 		sleep 5
 		# If we have a BATMAN_V env we need to correct the throughput value now


### PR DESCRIPTION
This reverts commit fd5f1c7e2345260db72105c16c6db8d57ce7b222.

The lack of mesh-vpn is due https://github.com/freifunk-gluon/gluon/commit/98a1c196ed8d76c0449ed85f291b4fac1ace9467 and requires a more in-depth change.