### PR TITLE
Fix mesh-vpn issues for Gluon v2022.1

### DIFF
--- a/ffmuc-mesh-vpn-wireguard-vxlan/files/lib/gluon/mesh-vpn/wireguard_pubkey.sh
+++ b/ffmuc-mesh-vpn-wireguard-vxlan/files/lib/gluon/mesh-vpn/wireguard_pubkey.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+/usr/bin/wg show wg_mesh_vpn public-key

--- a/ffmuc-mesh-vpn-wireguard-vxlan/luasrc/lib/gluon/upgrade/400-mesh-vpn-wireguard
+++ b/ffmuc-mesh-vpn-wireguard-vxlan/luasrc/lib/gluon/upgrade/400-mesh-vpn-wireguard
@@ -17,6 +17,7 @@ end)
 
 local mesh_enabled = uci:get_bool('gluon', 'mesh_vpn', 'enabled') -- default
 	or uci:get_bool('fastd', 'mesh_vpn', 'enabled') --migration
+	or not uci:get_bool('network', 'wg_mesh', 'disabled') --compatiblity with upstream
 	or wg_enabled -- specific config
 
 uci:section("wireguard", "wireguard", "mesh_vpn", {

--- a/ffmuc-mesh-vpn-wireguard-vxlan/luasrc/usr/lib/lua/gluon/mesh-vpn/provider/wireguard.lua
+++ b/ffmuc-mesh-vpn-wireguard-vxlan/luasrc/usr/lib/lua/gluon/mesh-vpn/provider/wireguard.lua
@@ -7,7 +7,13 @@ local vpn_core = require 'gluon.mesh-vpn'
 local M = {}
 
 function M.public_key()
-        return util.trim(util.exec('/usr/bin/wg show wg_mesh_vpn public-key'))
+        local key = util.trim(util.exec("/lib/gluon/mesh-vpn/wireguard_pubkey.sh"))
+
+        if key == '' then
+                key = nil
+        end
+
+        return key
 end
 
 function M.enable(val)

--- a/ffmuc-mesh-vpn-wireguard-vxlan/luasrc/usr/lib/lua/gluon/mesh-vpn/provider/wireguard.lua
+++ b/ffmuc-mesh-vpn-wireguard-vxlan/luasrc/usr/lib/lua/gluon/mesh-vpn/provider/wireguard.lua
@@ -33,4 +33,8 @@ function M.set_limit(ingress_limit, egress_limit)
         uci:save('simple-tc')
 end
 
+function M.mtu()
+        return site.mesh_vpn.wireguard.mtu()
+end
+
 return M


### PR DESCRIPTION
These 3 (pretty hacky) commits seem to fix the problem with mesh-vpn not working anymore with Gluon v2022.1